### PR TITLE
Fixed jshint error

### DIFF
--- a/app/templates/_gruntfile.js
+++ b/app/templates/_gruntfile.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
 			},
 			js: {
 				files: [
-					'<%= jshint.all %>'
+					'<%= jshintTag %>'
 				],
 				tasks: [
 					'jshint',


### PR DESCRIPTION
Seems jshint.all worked for me locally but gives a jshint crash when I try a new installation.
